### PR TITLE
Adding full ASCII support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barcode-scanner"
-version = "0.1.0"
+version = "0.1.1"
 description = "Linux interface to barcode USB hand scanners"
 license = "BSD-2-Clause OR Apache-2.0"
 repository = "https://github.com/robohouse-delft/barcode-scanner-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barcode-scanner"
-version = "0.1.1"
+version = "0.1.0"
 description = "Linux interface to barcode USB hand scanners"
 license = "BSD-2-Clause OR Apache-2.0"
 repository = "https://github.com/robohouse-delft/barcode-scanner-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ impl BarcodeScanner {
 			let mut shift_pressed = false;
 			for event in events {
 				// Check if key is pressed (value 1 for the key pressed, velue 0 for the key released).
-				if event.event_type() == evdev::EventType::KEY && event.value() == 1 {
+				if event.event_type() == evdev::EventType::KEY {
 					// Create Key object based on the code.
 					let key_name = evdev::Key(event.code());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,7 @@ fn key_to_str(key: evdev::Key, shift_pressed: bool) -> Option<char> {
         evdev::Key::KEY_Z => ['z','Z'],
         // Special
         evdev::Key::KEY_SPACE => [' ', ' '],
+        evdev::Key::KEY_TAB => ['\t', '\t'],
         evdev::Key::KEY_APOSTROPHE => ['\'', '"'],
         evdev::Key::KEY_EQUAL => ['=', '+'],
         evdev::Key::KEY_COMMA => [',', '<'],


### PR DESCRIPTION
I changed up the code for converting the keys returned by evdev to actual `chars`. It now takes holding down shift into account, so that upper-case is possible. Also I added in some missing character to allow full support of all printable ASCII characters minus DEL (so character code 32-126).

Also I bumped the version number.